### PR TITLE
Merge new/class/activity into new/class/event

### DIFF
--- a/src/main/java/seedu/taskman/commons/events/model/TaskManChangedEvent.java
+++ b/src/main/java/seedu/taskman/commons/events/model/TaskManChangedEvent.java
@@ -14,6 +14,6 @@ public class TaskManChangedEvent extends BaseEvent {
 
     @Override
     public String toString() {
-        return "number of tasks " + data.getTaskList().size() + ", number of tags " + data.getTagList().size();
+        return "number of tasks " + data.getActivityList().size() + ", number of tags " + data.getTagList().size();
     }
 }

--- a/src/main/java/seedu/taskman/commons/events/ui/TaskPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/taskman/commons/events/ui/TaskPanelSelectionChangedEvent.java
@@ -1,7 +1,7 @@
 package seedu.taskman.commons.events.ui;
 
 import seedu.taskman.commons.events.BaseEvent;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 
 /**
  * Represents a selection change in the Task List Panel
@@ -9,9 +9,9 @@ import seedu.taskman.model.event.ReadOnlyTask;
 public class TaskPanelSelectionChangedEvent extends BaseEvent {
 
 
-    private final ReadOnlyTask newSelection;
+    private final Activity newSelection;
 
-    public TaskPanelSelectionChangedEvent(ReadOnlyTask newSelection){
+    public TaskPanelSelectionChangedEvent(Activity newSelection){
         this.newSelection = newSelection;
     }
 
@@ -20,7 +20,7 @@ public class TaskPanelSelectionChangedEvent extends BaseEvent {
         return this.getClass().getSimpleName();
     }
 
-    public ReadOnlyTask getNewSelection() {
+    public Activity getNewSelection() {
         return newSelection;
     }
 }

--- a/src/main/java/seedu/taskman/logic/Logic.java
+++ b/src/main/java/seedu/taskman/logic/Logic.java
@@ -2,7 +2,7 @@ package seedu.taskman.logic;
 
 import javafx.collections.ObservableList;
 import seedu.taskman.logic.commands.CommandResult;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 
 /**
  * API of the Logic component
@@ -16,6 +16,6 @@ public interface Logic {
     CommandResult execute(String commandText);
 
     /** Returns the filtered list of tasks */
-    ObservableList<ReadOnlyTask> getFilteredTaskList();
+    ObservableList<Activity> getFilteredActivityList();
 
 }

--- a/src/main/java/seedu/taskman/logic/LogicManager.java
+++ b/src/main/java/seedu/taskman/logic/LogicManager.java
@@ -7,7 +7,7 @@ import seedu.taskman.logic.commands.Command;
 import seedu.taskman.logic.commands.CommandResult;
 import seedu.taskman.logic.parser.Parser;
 import seedu.taskman.model.Model;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.storage.Storage;
 
 import java.util.logging.Logger;
@@ -35,7 +35,7 @@ public class LogicManager extends ComponentManager implements Logic {
     }
 
     @Override
-    public ObservableList<ReadOnlyTask> getFilteredTaskList() {
-        return model.getFilteredTaskList();
+    public ObservableList<Activity> getFilteredActivityList() {
+        return model.getFilteredActivityList();
     }
 }

--- a/src/main/java/seedu/taskman/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/AddCommand.java
@@ -51,7 +51,7 @@ public class AddCommand extends Command {
         try {
             model.addTask(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
-        } catch (UniqueActivityList.DuplicateTaskException e) {
+        } catch (UniqueActivityList.DuplicateActivityException e) {
             return new CommandResult(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/taskman/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/AddCommand.java
@@ -51,7 +51,7 @@ public class AddCommand extends Command {
         try {
             model.addTask(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
-        } catch (UniqueTaskList.DuplicateTaskException e) {
+        } catch (UniqueActivityList.DuplicateTaskException e) {
             return new CommandResult(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/taskman/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/DeleteCommand.java
@@ -2,8 +2,8 @@ package seedu.taskman.logic.commands;
 
 import seedu.taskman.commons.core.Messages;
 import seedu.taskman.commons.core.UnmodifiableObservableList;
-import seedu.taskman.model.event.ReadOnlyTask;
-import seedu.taskman.model.event.UniqueTaskList.TaskNotFoundException;
+import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.UniqueActivityList.ActivityNotFoundException;
 
 /**
  * Deletes a task identified using it's last displayed index from the task man.
@@ -13,7 +13,7 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the task identified by the index number used in the last task listing.\n"
+            + ": Deletes the task or event identified by the index number used in the last activity listing.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
@@ -29,22 +29,22 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute() {
 
-        UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
+        UnmodifiableObservableList<Activity> lastShownList = model.getFilteredActivityList();
 
         if (lastShownList.size() < targetIndex) {
             indicateAttemptToExecuteIncorrectCommand();
             return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        ReadOnlyTask taskToDelete = lastShownList.get(targetIndex - 1);
+        Activity activityToDelete = lastShownList.get(targetIndex - 1);
 
         try {
-            model.deleteTask(taskToDelete);
-        } catch (TaskNotFoundException pnfe) {
+            model.deleteActivity(activityToDelete);
+        } catch (ActivityNotFoundException pnfe) {
             assert false : "The target task cannot be missing";
         }
 
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, taskToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, activityToDelete));
     }
 
 }

--- a/src/main/java/seedu/taskman/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/ListCommand.java
@@ -29,8 +29,8 @@ public class ListCommand extends Command {
             model.updateFilteredListToShowAll();
             return new CommandResult(MESSAGE_SUCCESS);
         } else {
-            model.updateFilteredTaskList(keywords);
-            return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
+            model.updateFilteredActivityList(keywords);
+            return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredActivityList().size()));
         }
     }
 

--- a/src/main/java/seedu/taskman/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/SelectCommand.java
@@ -3,7 +3,7 @@ package seedu.taskman.logic.commands;
 import seedu.taskman.commons.core.EventsCenter;
 import seedu.taskman.commons.core.Messages;
 import seedu.taskman.commons.events.ui.JumpToListRequestEvent;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.commons.core.UnmodifiableObservableList;
 
 /**
@@ -29,7 +29,7 @@ public class SelectCommand extends Command {
     @Override
     public CommandResult execute() {
 
-        UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
+        UnmodifiableObservableList<Activity> lastShownList = model.getFilteredActivityList();
 
         if (lastShownList.size() < targetIndex) {
             indicateAttemptToExecuteIncorrectCommand();

--- a/src/main/java/seedu/taskman/model/Model.java
+++ b/src/main/java/seedu/taskman/model/Model.java
@@ -1,9 +1,9 @@
 package seedu.taskman.model;
 
 import seedu.taskman.commons.core.UnmodifiableObservableList;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.model.event.Task;
-import seedu.taskman.model.event.UniqueTaskList;
+import seedu.taskman.model.event.UniqueActivityList;
 
 import java.util.Set;
 
@@ -17,19 +17,19 @@ public interface Model {
     /** Returns the TaskMan */
     ReadOnlyTaskMan getTaskMan();
 
-    /** Deletes the given task. */
-    void deleteTask(ReadOnlyTask target) throws UniqueTaskList.TaskNotFoundException;
+    /** Deletes the given activity. */
+    void deleteActivity(Activity target) throws UniqueActivityList.ActivityNotFoundException;
 
     /** Adds the given task */
-    void addTask(Task task) throws UniqueTaskList.DuplicateTaskException;
+    void addTask(Task task) throws UniqueActivityList.DuplicateTaskException;
 
-    /** Returns the filtered task list as an {@code UnmodifiableObservableList<ReadOnlyTask>} */
-    UnmodifiableObservableList<ReadOnlyTask> getFilteredTaskList();
+    /** Returns the filtered task list as an {@code UnmodifiableObservableList<Activity>} */
+    UnmodifiableObservableList<Activity> getFilteredActivityList();
 
     /** Updates the filter of the filtered task list to show all tasks */
     void updateFilteredListToShowAll();
 
     /** Updates the filter of the filtered task list to filter by the given keywords*/
-    void updateFilteredTaskList(Set<String> keywords);
+    void updateFilteredActivityList(Set<String> keywords);
 
 }

--- a/src/main/java/seedu/taskman/model/Model.java
+++ b/src/main/java/seedu/taskman/model/Model.java
@@ -21,7 +21,7 @@ public interface Model {
     void deleteActivity(Activity target) throws UniqueActivityList.ActivityNotFoundException;
 
     /** Adds the given task */
-    void addTask(Task task) throws UniqueActivityList.DuplicateTaskException;
+    void addTask(Task task) throws UniqueActivityList.DuplicateActivityException;
 
     /** Returns the filtered task list as an {@code UnmodifiableObservableList<Activity>} */
     UnmodifiableObservableList<Activity> getFilteredActivityList();

--- a/src/main/java/seedu/taskman/model/ModelManager.java
+++ b/src/main/java/seedu/taskman/model/ModelManager.java
@@ -23,7 +23,6 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final TaskMan taskMan;
     private final FilteredList<Activity> filteredActivities;
-    // TODO: add filteredEvents list
 
     /**
      * Initializes a ModelManager with the given TaskMan

--- a/src/main/java/seedu/taskman/model/ModelManager.java
+++ b/src/main/java/seedu/taskman/model/ModelManager.java
@@ -71,7 +71,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public synchronized void addTask(Task task) throws UniqueActivityList.DuplicateTaskException {
+    public synchronized void addTask(Task task) throws UniqueActivityList.DuplicateActivityException {
         taskMan.addTask(task);
         updateFilteredListToShowAll();
         indicateTaskManChanged();

--- a/src/main/java/seedu/taskman/model/ModelManager.java
+++ b/src/main/java/seedu/taskman/model/ModelManager.java
@@ -1,15 +1,15 @@
 package seedu.taskman.model;
 
 import javafx.collections.transformation.FilteredList;
+import seedu.taskman.commons.core.ComponentManager;
 import seedu.taskman.commons.core.LogsCenter;
 import seedu.taskman.commons.core.UnmodifiableObservableList;
 import seedu.taskman.commons.events.model.TaskManChangedEvent;
 import seedu.taskman.commons.util.StringUtil;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.model.event.Task;
-import seedu.taskman.model.event.UniqueTaskList;
-import seedu.taskman.model.event.UniqueTaskList.TaskNotFoundException;
-import seedu.taskman.commons.core.ComponentManager;
+import seedu.taskman.model.event.UniqueActivityList;
+import seedu.taskman.model.event.UniqueActivityList.ActivityNotFoundException;
 
 import java.util.Set;
 import java.util.logging.Logger;
@@ -22,7 +22,7 @@ public class ModelManager extends ComponentManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
     private final TaskMan taskMan;
-    private final FilteredList<Task> filteredTasks;
+    private final FilteredList<Activity> filteredActivities;
     // TODO: add filteredEvents list
 
     /**
@@ -37,7 +37,7 @@ public class ModelManager extends ComponentManager implements Model {
         logger.fine("Initializing with Task Man: " + src + " and user prefs " + userPrefs);
 
         taskMan = new TaskMan(src);
-        filteredTasks = new FilteredList<>(taskMan.getTasks());
+        filteredActivities = new FilteredList<>(taskMan.getActivities());
     }
 
     public ModelManager() {
@@ -46,7 +46,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     public ModelManager(ReadOnlyTaskMan initialData, UserPrefs userPrefs) {
         taskMan = new TaskMan(initialData);
-        filteredTasks = new FilteredList<>(taskMan.getTasks());
+        filteredActivities = new FilteredList<>(taskMan.getActivities());
     }
 
     @Override
@@ -65,13 +65,13 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public synchronized void deleteTask(ReadOnlyTask target) throws TaskNotFoundException {
-        taskMan.removeTask(target);
+    public synchronized void deleteActivity(Activity target) throws ActivityNotFoundException {
+        taskMan.removeActivity(target);
         indicateTaskManChanged();
     }
 
     @Override
-    public synchronized void addTask(Task task) throws UniqueTaskList.DuplicateTaskException {
+    public synchronized void addTask(Task task) throws UniqueActivityList.DuplicateTaskException {
         taskMan.addTask(task);
         updateFilteredListToShowAll();
         indicateTaskManChanged();
@@ -80,28 +80,28 @@ public class ModelManager extends ComponentManager implements Model {
     //=========== Filtered Task List Accessors ===============================================================
 
     @Override
-    public UnmodifiableObservableList<ReadOnlyTask> getFilteredTaskList() {
-        return new UnmodifiableObservableList<>(filteredTasks);
+    public UnmodifiableObservableList<Activity> getFilteredActivityList() {
+        return new UnmodifiableObservableList<>(filteredActivities);
     }
 
     @Override
     public void updateFilteredListToShowAll() {
-        filteredTasks.setPredicate(null);
+        filteredActivities.setPredicate(null);
     }
 
     @Override
-    public void updateFilteredTaskList(Set<String> keywords){
+    public void updateFilteredActivityList(Set<String> keywords){
         updateFilteredTaskList(new PredicateExpression(new TitleQualifier(keywords)));
     }
 
     private void updateFilteredTaskList(Expression expression) {
-        filteredTasks.setPredicate(expression::satisfies);
+        filteredActivities.setPredicate(expression::satisfies);
     }
 
     //========== Inner classes/interfaces used for filtering ==================================================
 
     interface Expression {
-        boolean satisfies(ReadOnlyTask task);
+        boolean satisfies(Activity task);
         String toString();
     }
 
@@ -114,8 +114,8 @@ public class ModelManager extends ComponentManager implements Model {
         }
 
         @Override
-        public boolean satisfies(ReadOnlyTask task) {
-            return qualifier.run(task);
+        public boolean satisfies(Activity activity) {
+            return qualifier.run(activity);
         }
 
         @Override
@@ -125,7 +125,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     interface Qualifier {
-        boolean run(ReadOnlyTask task);
+        boolean run(Activity activity);
         String toString();
     }
 
@@ -137,9 +137,9 @@ public class ModelManager extends ComponentManager implements Model {
         }
 
         @Override
-        public boolean run(ReadOnlyTask task) {
+        public boolean run(Activity activity) {
             return titleKeyWords.stream()
-                    .filter(keyword -> StringUtil.containsIgnoreCase(task.getTitle().title, keyword))
+                    .filter(keyword -> StringUtil.containsIgnoreCase(activity.getTitle().title, keyword))
                     .findAny()
                     .isPresent();
         }

--- a/src/main/java/seedu/taskman/model/ReadOnlyTaskMan.java
+++ b/src/main/java/seedu/taskman/model/ReadOnlyTaskMan.java
@@ -3,8 +3,8 @@ package seedu.taskman.model;
 
 import seedu.taskman.model.tag.Tag;
 import seedu.taskman.model.tag.UniqueTagList;
-import seedu.taskman.model.event.ReadOnlyTask;
-import seedu.taskman.model.event.UniqueTaskList;
+import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.UniqueActivityList;
 
 import java.util.List;
 
@@ -15,12 +15,12 @@ public interface ReadOnlyTaskMan {
 
     UniqueTagList getUniqueTagList();
 
-    UniqueTaskList getUniqueTaskList();
+    UniqueActivityList getUniqueActivityList();
 
     /**
      * Returns an unmodifiable view of tasks list
      */
-    List<ReadOnlyTask> getTaskList();
+    List<Activity> getActivityList();
 
     /**
      * Returns an unmodifiable view of tags list

--- a/src/main/java/seedu/taskman/model/TaskMan.java
+++ b/src/main/java/seedu/taskman/model/TaskMan.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
  */
 public class TaskMan implements ReadOnlyTaskMan {
 
-    // todo: change to UniqueActivityList
     private final UniqueActivityList activities;
     private final UniqueTagList tags;
 
@@ -30,7 +29,6 @@ public class TaskMan implements ReadOnlyTaskMan {
 
     /**
      * Tasks and Tags are copied into this taskMan
-     * // todo: add unique event list
      */
     public TaskMan(ReadOnlyTaskMan toBeCopied) {
         this(toBeCopied.getUniqueActivityList(), toBeCopied.getUniqueTagList());

--- a/src/main/java/seedu/taskman/model/TaskMan.java
+++ b/src/main/java/seedu/taskman/model/TaskMan.java
@@ -1,11 +1,11 @@
 package seedu.taskman.model;
 
 import javafx.collections.ObservableList;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.model.tag.Tag;
 import seedu.taskman.model.tag.UniqueTagList;
-import seedu.taskman.model.event.ReadOnlyTask;
 import seedu.taskman.model.event.Task;
-import seedu.taskman.model.event.UniqueTaskList;
+import seedu.taskman.model.event.UniqueActivityList;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -17,12 +17,12 @@ import java.util.stream.Collectors;
 public class TaskMan implements ReadOnlyTaskMan {
 
     // todo: change to UniqueActivityList
-    private final UniqueTaskList tasks;
+    private final UniqueActivityList activities;
     private final UniqueTagList tags;
 
     // todo: format looks pretty weird. can we do smth about it?
     {
-        tasks = new UniqueTaskList();
+        activities = new UniqueActivityList();
         tags = new UniqueTagList();
     }
 
@@ -33,14 +33,14 @@ public class TaskMan implements ReadOnlyTaskMan {
      * // todo: add unique event list
      */
     public TaskMan(ReadOnlyTaskMan toBeCopied) {
-        this(toBeCopied.getUniqueTaskList(), toBeCopied.getUniqueTagList());
+        this(toBeCopied.getUniqueActivityList(), toBeCopied.getUniqueTagList());
     }
 
     /**
      * Tasks and Tags are copied into this taskMan
      */
-    public TaskMan(UniqueTaskList tasks, UniqueTagList tags) {
-        resetData(tasks.getInternalList(), tags.getInternalList());
+    public TaskMan(UniqueActivityList activities, UniqueTagList tags) {
+        resetData(activities.getInternalList(), tags.getInternalList());
     }
 
     // TODO: review, do we really need this
@@ -50,12 +50,12 @@ public class TaskMan implements ReadOnlyTaskMan {
 
 //// list overwrite operations
 
-    public ObservableList<Task> getTasks() {
-        return tasks.getInternalList();
+    public ObservableList<Activity> getActivities() {
+        return activities.getInternalList();
     }
 
-    public void setTasks(List<Task> tasks) {
-        this.tasks.getInternalList().setAll(tasks);
+    public void setActivities(List<Activity> activities) {
+        this.activities.getInternalList().setAll(activities);
     }
 
     // TODO: create set event
@@ -64,13 +64,13 @@ public class TaskMan implements ReadOnlyTaskMan {
         this.tags.getInternalList().setAll(tags);
     }
 
-    public void resetData(Collection<? extends ReadOnlyTask> newTasks, Collection<Tag> newTags) {
-        setTasks(newTasks.stream().map(Task::new).collect(Collectors.toList()));
+    public void resetData(Collection<? extends Activity> newActivities, Collection<Tag> newTags) {
+        setActivities(newActivities.stream().map(Activity::new).collect(Collectors.toList()));
         setTags(newTags);
     }
 
     public void resetData(ReadOnlyTaskMan newData) {
-        resetData(newData.getTaskList(), newData.getTagList());
+        resetData(newData.getActivityList(), newData.getTagList());
     }
 
 //// task-level operations
@@ -80,11 +80,11 @@ public class TaskMan implements ReadOnlyTaskMan {
      * Also checks the new task's tags and updates {@link #tags} with any new tags found,
      * and updates the Tag objects in the task to point to those in {@link #tags}.
      *
-     * @throws UniqueTaskList.DuplicateTaskException if an equivalent task already exists.
+     * @throws UniqueActivityList.DuplicateTaskException if an equivalent task already exists.
      */
-    public void addTask(Task p) throws UniqueTaskList.DuplicateTaskException {
+    public void addTask(Task p) throws UniqueActivityList.DuplicateTaskException {
         syncTagsWithMasterList(p);
-        tasks.add(p);
+        activities.add(new Activity(p));
     }
 
     /**
@@ -111,11 +111,11 @@ public class TaskMan implements ReadOnlyTaskMan {
         task.setTags(new UniqueTagList(commonTagReferences));
     }
 
-    public boolean removeTask(ReadOnlyTask key) throws UniqueTaskList.TaskNotFoundException {
-        if (tasks.remove(key)) {
+    public boolean removeActivity(Activity key) throws UniqueActivityList.ActivityNotFoundException {
+        if (activities.remove(key)) {
             return true;
         } else {
-            throw new UniqueTaskList.TaskNotFoundException();
+            throw new UniqueActivityList.ActivityNotFoundException();
         }
     }
 
@@ -129,12 +129,12 @@ public class TaskMan implements ReadOnlyTaskMan {
 
     @Override
     public String toString() {
-        return tasks.getInternalList().size() + " tasks, " + tags.getInternalList().size() +  " tags";
+        return activities.getInternalList().size() + " activities, " + tags.getInternalList().size() +  " tags";
     }
 
     @Override
-    public List<ReadOnlyTask> getTaskList() {
-        return Collections.unmodifiableList(tasks.getInternalList());
+    public List<Activity> getActivityList() {
+        return Collections.unmodifiableList(activities.getInternalList());
     }
 
     @Override
@@ -143,8 +143,8 @@ public class TaskMan implements ReadOnlyTaskMan {
     }
 
     @Override
-    public UniqueTaskList getUniqueTaskList() {
-        return this.tasks;
+    public UniqueActivityList getUniqueActivityList() {
+        return this.activities;
     }
 
     @Override
@@ -157,13 +157,13 @@ public class TaskMan implements ReadOnlyTaskMan {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TaskMan // instanceof handles nulls
-                && this.tasks.equals(((TaskMan) other).tasks)
+                && this.activities.equals(((TaskMan) other).activities)
                 && this.tags.equals(((TaskMan) other).tags));
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(tasks, tags);
+        return Objects.hash(activities, tags);
     }
 }

--- a/src/main/java/seedu/taskman/model/TaskMan.java
+++ b/src/main/java/seedu/taskman/model/TaskMan.java
@@ -80,9 +80,9 @@ public class TaskMan implements ReadOnlyTaskMan {
      * Also checks the new task's tags and updates {@link #tags} with any new tags found,
      * and updates the Tag objects in the task to point to those in {@link #tags}.
      *
-     * @throws UniqueActivityList.DuplicateTaskException if an equivalent task already exists.
+     * @throws UniqueActivityList.DuplicateActivityException if an equivalent task already exists.
      */
-    public void addTask(Task p) throws UniqueActivityList.DuplicateTaskException {
+    public void addTask(Task p) throws UniqueActivityList.DuplicateActivityException {
         syncTagsWithMasterList(p);
         activities.add(new Activity(p));
     }

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -1,0 +1,70 @@
+package seedu.taskman.model.event;
+
+import seedu.taskman.model.tag.UniqueTagList;
+
+import java.util.Optional;
+
+/**
+ * Wrapper for both ReadOnlyEvent and ReadOnlyTask
+ *
+ * May i
+ */
+public class Activity{
+
+    public enum ActivityType {EVENT, TASK};
+
+    private ReadOnlyEvent activity;
+    private ActivityType type;
+
+    public Activity(ReadOnlyEvent event){
+        activity = event;
+        type = ActivityType.EVENT;
+    }
+
+    public Activity(ReadOnlyTask task){
+        activity = task;
+        type = ActivityType.TASK;
+    }
+
+    public ActivityType getType(){
+        return type;
+    }
+
+    public Optional<Status> getStatus() {
+        switch(type){
+            case TASK:
+                return Optional.ofNullable(((ReadOnlyTask)activity).getStatus());
+            case EVENT:
+            default:
+                return null;
+        }
+    }
+
+    public Optional<Deadline> getDeadline() {
+        switch(type){
+            case TASK:
+                return ((ReadOnlyTask)activity).getDeadline();
+            case EVENT:
+            default:
+                return Optional.empty();
+        }
+    }
+
+
+    public Title getTitle() {
+        return activity.getTitle();
+    }
+
+    public Optional<Frequency> getFrequency() {
+        return activity.getFrequency();
+    }
+
+    public Optional<Schedule> getSchedule() {
+        return activity.getSchedule();
+    }
+
+    public UniqueTagList getTags() {
+        return activity.getTags();
+    }
+
+}

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -2,6 +2,7 @@ package seedu.taskman.model.event;
 
 import seedu.taskman.model.tag.UniqueTagList;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -26,6 +27,15 @@ public class Activity implements ReadOnlyEvent{
 
     public ActivityType getType(){
         return type;
+    }
+
+    public ReadOnlyTask getTask(){
+        assert type == ActivityType.TASK;
+        return (ReadOnlyTask) activity;
+    }
+
+    public ReadOnlyEvent getEvent(){
+        return activity;
     }
 
     public Optional<Status> getStatus() {
@@ -68,9 +78,36 @@ public class Activity implements ReadOnlyEvent{
         return activity.getTags();
     }
 
+    public boolean isSameStateAs(Activity other){
+        if(type != other.type) return false;
+
+        switch(type){
+            case TASK:
+                return getTask().isSameStateAs(other.getTask());
+            case EVENT:
+            default:
+                return activity.isSameStateAs(other.activity);
+        }
+    }
+
     @Override
-    public boolean isSameStateAs(ReadOnlyEvent other) {
-        return other.isSameStateAs(activity);
+    public boolean equals(Object other){
+        return other == this // short circuit if same object
+                || (other instanceof Activity // instanceof handles nulls
+                && this.isSameStateAs((Activity) other));
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(
+                getTitle(),
+                getDeadline(),
+                getStatus(),
+                getFrequency(),
+                getSchedule(),
+                getTags()
+        );
     }
 
     @Override

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -6,10 +6,8 @@ import java.util.Optional;
 
 /**
  * Wrapper for both ReadOnlyEvent and ReadOnlyTask
- *
- * May i
  */
-public class Activity{
+public class Activity implements ReadOnlyEvent{
 
     public enum ActivityType {EVENT, TASK};
 
@@ -50,21 +48,38 @@ public class Activity{
         }
     }
 
-
+    @Override
     public Title getTitle() {
         return activity.getTitle();
     }
 
+    @Override
     public Optional<Frequency> getFrequency() {
         return activity.getFrequency();
     }
 
+    @Override
     public Optional<Schedule> getSchedule() {
         return activity.getSchedule();
     }
 
+    @Override
     public UniqueTagList getTags() {
         return activity.getTags();
+    }
+
+    @Override
+    public boolean isSameStateAs(ReadOnlyEvent other) {
+        return activity.isSameStateAs(other);
+    }
+
+    public boolean isSameStateAs(ReadOnlyTask task) {
+        return task.isSameStateAs(activity);
+    }
+
+    @Override
+    public String getAsText() {
+        return activity.getAsText();
     }
 
 }

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -27,12 +27,14 @@ public class Activity implements ReadOnlyEvent{
 
     public Activity(Activity source){
         switch (source.getType()){
-            case TASK:
+            case TASK: {
                 this.activity = new Task((ReadOnlyTask) source.activity);
                 break;
+            }
             case EVENT:
-            default:
+            default: {
                 this.activity = new Event(source.getEvent());
+            }
         }
         type = source.getType();
     }
@@ -54,21 +56,25 @@ public class Activity implements ReadOnlyEvent{
 
     public Optional<Status> getStatus() {
         switch(type){
-            case TASK:
-                return Optional.ofNullable(((ReadOnlyTask)activity).getStatus());
+            case TASK: {
+                return Optional.ofNullable(((ReadOnlyTask) activity).getStatus());
+            }
             case EVENT:
-            default:
-                return null;
+            default: {
+                return Optional.empty();
+            }
         }
     }
 
     public Optional<Deadline> getDeadline() {
         switch(type){
-            case TASK:
-                return ((ReadOnlyTask)activity).getDeadline();
+            case TASK: {
+                return ((ReadOnlyTask) activity).getDeadline();
+            }
             case EVENT:
-            default:
+            default: {
                 return Optional.empty();
+            }
         }
     }
 
@@ -96,11 +102,13 @@ public class Activity implements ReadOnlyEvent{
         if(type != other.type) return false;
 
         switch(type){
-            case TASK:
-                return ((ReadOnlyTask)activity).isSameStateAs((ReadOnlyTask)other.activity);
+            case TASK: {
+                return ((ReadOnlyTask) activity).isSameStateAs((ReadOnlyTask) other.activity);
+            }
             case EVENT:
-            default:
+            default: {
                 return activity.isSameStateAs(other.activity);
+            }
         }
     }
 

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -28,7 +28,7 @@ public class Activity implements ReadOnlyEvent{
     public Activity(Activity source){
         switch (source.getType()){
             case TASK:
-                this.activity = new Task(source.getTask());
+                this.activity = new Task((ReadOnlyTask) source.activity);
                 break;
             case EVENT:
             default:
@@ -41,9 +41,11 @@ public class Activity implements ReadOnlyEvent{
         return type;
     }
 
-    public ReadOnlyTask getTask(){
-        assert type == ActivityType.TASK;
-        return (ReadOnlyTask) activity;
+    public Optional<ReadOnlyTask> getTask(){
+        if(type != ActivityType.TASK){
+            return Optional.empty();
+        }
+        return Optional.of((ReadOnlyTask) activity);
     }
 
     public ReadOnlyEvent getEvent(){
@@ -95,7 +97,7 @@ public class Activity implements ReadOnlyEvent{
 
         switch(type){
             case TASK:
-                return getTask().isSameStateAs(other.getTask());
+                return ((ReadOnlyTask)activity).isSameStateAs((ReadOnlyTask)other.activity);
             case EVENT:
             default:
                 return activity.isSameStateAs(other.activity);

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -70,11 +70,7 @@ public class Activity implements ReadOnlyEvent{
 
     @Override
     public boolean isSameStateAs(ReadOnlyEvent other) {
-        return activity.isSameStateAs(other);
-    }
-
-    public boolean isSameStateAs(ReadOnlyTask task) {
-        return task.isSameStateAs(activity);
+        return other.isSameStateAs(activity);
     }
 
     @Override

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -25,6 +25,18 @@ public class Activity implements ReadOnlyEvent{
         type = ActivityType.TASK;
     }
 
+    public Activity(Activity source){
+        switch (source.getType()){
+            case TASK:
+                this.activity = new Task(source.getTask());
+                break;
+            case EVENT:
+            default:
+                this.activity = new Event(source.getEvent());
+        }
+        type = source.getType();
+    }
+
     public ActivityType getType(){
         return type;
     }

--- a/src/main/java/seedu/taskman/model/event/Task.java
+++ b/src/main/java/seedu/taskman/model/event/Task.java
@@ -6,7 +6,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * Represents a Task in the task man.

--- a/src/main/java/seedu/taskman/model/event/UniqueActivityList.java
+++ b/src/main/java/seedu/taskman/model/event/UniqueActivityList.java
@@ -20,9 +20,9 @@ public class UniqueActivityList implements Iterable<Activity> {
     /**
      * Signals that an operation would have violated the 'no duplicates' property of the list.
      */
-    public static class DuplicateTaskException extends DuplicateDataException {
-        protected DuplicateTaskException() {
-            super("Operation would result in duplicate tasks");
+    public static class DuplicateActivityException extends DuplicateDataException {
+        protected DuplicateActivityException() {
+            super("Operation would result in duplicate activities");
         }
     }
 
@@ -50,12 +50,12 @@ public class UniqueActivityList implements Iterable<Activity> {
     /**
      * Adds a task to the list.
      *
-     * @throws DuplicateTaskException if the task to add is a duplicate of an existing task in the list.
+     * @throws DuplicateActivityException if the task to add is a duplicate of an existing task in the list.
      */
-    public void add(Activity toAdd) throws DuplicateTaskException {
+    public void add(Activity toAdd) throws DuplicateActivityException {
         assert toAdd != null;
         if (contains(toAdd)) {
-            throw new DuplicateTaskException();
+            throw new DuplicateActivityException();
         }
         internalList.add(toAdd);
     }

--- a/src/main/java/seedu/taskman/model/event/UniqueActivityList.java
+++ b/src/main/java/seedu/taskman/model/event/UniqueActivityList.java
@@ -8,14 +8,14 @@ import seedu.taskman.commons.exceptions.DuplicateDataException;
 import java.util.*;
 
 /**
- * A list of tasks that enforces uniqueness between its elements and does not allow nulls.
+ * A list of activities that enforces uniqueness between its elements and does not allow nulls.
  *
  * Supports a minimal set of list operations.
  *
- * @see Task#equals(Object)
+ * @see Activity#equals(Object)
  * @see CollectionUtil#elementsAreUnique(Collection)
  */
-public class UniqueTaskList implements Iterable<Task> {
+public class UniqueActivityList implements Iterable<Activity> {
 
     /**
      * Signals that an operation would have violated the 'no duplicates' property of the list.
@@ -30,19 +30,19 @@ public class UniqueTaskList implements Iterable<Task> {
      * Signals that an operation targeting a specified task in the list would fail because
      * there is no such matching task in the list.
      */
-    public static class TaskNotFoundException extends Exception {}
+    public static class ActivityNotFoundException extends Exception {}
 
-    private final ObservableList<Task> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Activity> internalList = FXCollections.observableArrayList();
 
     /**
      * Constructs empty TaskList.
      */
-    public UniqueTaskList() {}
+    public UniqueActivityList() {}
 
     /**
      * Returns true if the list contains an equivalent task as the given argument.
      */
-    public boolean contains(ReadOnlyTask toCheck) {
+    public boolean contains(Activity toCheck) {
         assert toCheck != null;
         return internalList.contains(toCheck);
     }
@@ -52,7 +52,7 @@ public class UniqueTaskList implements Iterable<Task> {
      *
      * @throws DuplicateTaskException if the task to add is a duplicate of an existing task in the list.
      */
-    public void add(Task toAdd) throws DuplicateTaskException {
+    public void add(Activity toAdd) throws DuplicateTaskException {
         assert toAdd != null;
         if (contains(toAdd)) {
             throw new DuplicateTaskException();
@@ -63,32 +63,32 @@ public class UniqueTaskList implements Iterable<Task> {
     /**
      * Removes the equivalent task from the list.
      *
-     * @throws TaskNotFoundException if no such task could be found in the list.
+     * @throws ActivityNotFoundException if no such task could be found in the list.
      */
-    public boolean remove(ReadOnlyTask toRemove) throws TaskNotFoundException {
+    public boolean remove(Activity toRemove) throws ActivityNotFoundException {
         assert toRemove != null;
-        final boolean taskFoundAndDeleted = internalList.remove(toRemove);
-        if (!taskFoundAndDeleted) {
-            throw new TaskNotFoundException();
+        final boolean activityFoundAndDeleted = internalList.remove(toRemove);
+        if (!activityFoundAndDeleted) {
+            throw new ActivityNotFoundException();
         }
-        return taskFoundAndDeleted;
+        return activityFoundAndDeleted;
     }
 
-    public ObservableList<Task> getInternalList() {
+    public ObservableList<Activity> getInternalList() {
         return internalList;
     }
 
     @Override
-    public Iterator<Task> iterator() {
+    public Iterator<Activity> iterator() {
         return internalList.iterator();
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof UniqueTaskList // instanceof handles nulls
+                || (other instanceof UniqueActivityList // instanceof handles nulls
                 && this.internalList.equals(
-                ((UniqueTaskList) other).internalList));
+                ((UniqueActivityList) other).internalList));
     }
 
     @Override

--- a/src/main/java/seedu/taskman/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/taskman/storage/XmlAdaptedTask.java
@@ -58,6 +58,28 @@ public class XmlAdaptedTask {
         }
     }
 
+    //TODO: remove after XmlAdaptedEvent is completed.
+    public XmlAdaptedTask(Activity source) {
+        title = source.getTitle().title;
+        deadline = source.getDeadline().isPresent()
+                ? source.getDeadline().get().toString()
+                : null;
+        status = source.getStatus().isPresent()
+                ? source.getStatus().get().toString()
+                : null;
+        schedule = source.getSchedule().isPresent()
+                ? source.getSchedule().get().toString()
+                : null;
+        frequency = source.getFrequency().isPresent()
+                ? source.getFrequency().get().toString()
+                : null;
+        tagged = new ArrayList<>();
+        for (Tag tag : source.getTags()) {
+            tagged.add(new XmlAdaptedTag(tag));
+        }
+    }
+
+
     /**
      * Converts this JAXB-friendly adapted task object into the model's Task object.
      *

--- a/src/main/java/seedu/taskman/storage/XmlSerializableTaskMan.java
+++ b/src/main/java/seedu/taskman/storage/XmlSerializableTaskMan.java
@@ -1,10 +1,10 @@
 package seedu.taskman.storage;
 
 import seedu.taskman.commons.exceptions.IllegalValueException;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.model.tag.Tag;
 import seedu.taskman.model.tag.UniqueTagList;
-import seedu.taskman.model.event.ReadOnlyTask;
-import seedu.taskman.model.event.UniqueTaskList;
+import seedu.taskman.model.event.UniqueActivityList;
 import seedu.taskman.model.ReadOnlyTaskMan;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -39,7 +39,9 @@ public class XmlSerializableTaskMan implements ReadOnlyTaskMan {
      * Conversion
      */
     public XmlSerializableTaskMan(ReadOnlyTaskMan src) {
-        tasks.addAll(src.getTaskList().stream().map(XmlAdaptedTask::new).collect(Collectors.toList()));
+        //TODO: writing tasks and events
+        //implemented XmlAdaptedTask(Activity activity) for now
+        tasks.addAll(src.getActivityList().stream().map(XmlAdaptedTask::new).collect(Collectors.toList()));
         tags = src.getTagList();
     }
 
@@ -55,11 +57,11 @@ public class XmlSerializableTaskMan implements ReadOnlyTaskMan {
     }
 
     @Override
-    public UniqueTaskList getUniqueTaskList() {
-        UniqueTaskList lists = new UniqueTaskList();
+    public UniqueActivityList getUniqueActivityList() {
+        UniqueActivityList lists = new UniqueActivityList();
         for (XmlAdaptedTask p : tasks) {
             try {
-                lists.add(p.toModelType());
+                lists.add(new Activity(p.toModelType()));
             } catch (IllegalValueException e) {
                 //TODO: better error handling
             }
@@ -68,10 +70,10 @@ public class XmlSerializableTaskMan implements ReadOnlyTaskMan {
     }
 
     @Override
-    public List<ReadOnlyTask> getTaskList() {
+    public List<Activity> getActivityList() {
         return tasks.stream().map(p -> {
             try {
-                return p.toModelType();
+                return new Activity(p.toModelType());
             } catch (IllegalValueException e) {
                 e.printStackTrace();
                 //TODO: better error handling

--- a/src/main/java/seedu/taskman/ui/BrowserPanel.java
+++ b/src/main/java/seedu/taskman/ui/BrowserPanel.java
@@ -5,7 +5,7 @@ import javafx.scene.Node;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.web.WebView;
 import seedu.taskman.commons.util.FxViewUtil;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.commons.core.LogsCenter;
 
 import java.util.logging.Logger;
@@ -50,7 +50,7 @@ public class BrowserPanel extends UiPart{
         return browserPanel;
     }
 
-    public void loadTaskPage(ReadOnlyTask task) {
+    public void loadTaskPage(Activity task) {
         loadPage("https://www.google.com.sg/#safe=off&q=" + task.getTitle().title.replaceAll(" ", "+"));
     }
 

--- a/src/main/java/seedu/taskman/ui/MainWindow.java
+++ b/src/main/java/seedu/taskman/ui/MainWindow.java
@@ -13,7 +13,7 @@ import seedu.taskman.commons.core.GuiSettings;
 import seedu.taskman.commons.events.ui.ExitAppRequestEvent;
 import seedu.taskman.logic.Logic;
 import seedu.taskman.model.UserPrefs;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -109,7 +109,7 @@ public class MainWindow extends UiPart {
 
     void fillInnerParts() {
         browserPanel = BrowserPanel.load(browserPlaceholder);
-        taskListPanel = TaskListPanel.load(primaryStage, getTaskListPlaceholder(), logic.getFilteredTaskList());
+        taskListPanel = TaskListPanel.load(primaryStage, getTaskListPlaceholder(), logic.getFilteredActivityList());
         resultDisplay = ResultDisplay.load(primaryStage, getResultDisplayPlaceholder());
         statusBarFooter = StatusBarFooter.load(primaryStage, getStatusbarPlaceholder(), config.getTaskManFilePath());
         commandBox = CommandBox.load(primaryStage, getCommandBoxPlaceholder(), resultDisplay, logic);
@@ -186,7 +186,7 @@ public class MainWindow extends UiPart {
         return this.taskListPanel;
     }
 
-    public void loadTaskPage(ReadOnlyTask task) {
+    public void loadTaskPage(Activity task) {
         browserPanel.loadTaskPage(task);
     }
 

--- a/src/main/java/seedu/taskman/ui/TaskCard.java
+++ b/src/main/java/seedu/taskman/ui/TaskCard.java
@@ -4,7 +4,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 
 public class TaskCard extends UiPart{
 
@@ -27,14 +27,14 @@ public class TaskCard extends UiPart{
     @FXML
     private Label tags;
 
-    private ReadOnlyTask task;
+    private Activity task;
     private int displayedIndex;
 
     public TaskCard(){
 
     }
 
-    public static TaskCard load(ReadOnlyTask task, int displayedIndex){
+    public static TaskCard load(Activity task, int displayedIndex){
         TaskCard card = new TaskCard();
         card.task = task;
         card.displayedIndex = displayedIndex;

--- a/src/main/java/seedu/taskman/ui/TaskListPanel.java
+++ b/src/main/java/seedu/taskman/ui/TaskListPanel.java
@@ -11,7 +11,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.taskman.commons.events.ui.TaskPanelSelectionChangedEvent;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.commons.core.LogsCenter;
 
 import java.util.logging.Logger;
@@ -26,7 +26,7 @@ public class TaskListPanel extends UiPart {
     private AnchorPane placeHolderPane;
 
     @FXML
-    private ListView<ReadOnlyTask> taskListView;
+    private ListView<Activity> taskListView;
 
     public TaskListPanel() {
         super();
@@ -48,19 +48,19 @@ public class TaskListPanel extends UiPart {
     }
 
     public static TaskListPanel load(Stage primaryStage, AnchorPane taskListPlaceholder,
-                                       ObservableList<ReadOnlyTask> taskList) {
+                                       ObservableList<Activity> taskList) {
         TaskListPanel taskListPanel =
                 UiPartLoader.loadUiPart(primaryStage, taskListPlaceholder, new TaskListPanel());
         taskListPanel.configure(taskList);
         return taskListPanel;
     }
 
-    private void configure(ObservableList<ReadOnlyTask> taskList) {
+    private void configure(ObservableList<Activity> taskList) {
         setConnections(taskList);
         addToPlaceholder();
     }
 
-    private void setConnections(ObservableList<ReadOnlyTask> taskList) {
+    private void setConnections(ObservableList<Activity> taskList) {
         taskListView.setItems(taskList);
         taskListView.setCellFactory(listView -> new TaskListViewCell());
         setEventHandlerForSelectionChangeEvent();
@@ -87,13 +87,13 @@ public class TaskListPanel extends UiPart {
         });
     }
 
-    class TaskListViewCell extends ListCell<ReadOnlyTask> {
+    class TaskListViewCell extends ListCell<Activity> {
 
         public TaskListViewCell() {
         }
 
         @Override
-        protected void updateItem(ReadOnlyTask task, boolean empty) {
+        protected void updateItem(Activity task, boolean empty) {
             super.updateItem(task, empty);
 
             if (empty || task == null) {

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -1,9 +1,9 @@
 package guitests;
 
 import guitests.guihandles.TaskCardHandle;
-import org.junit.Test;
-import seedu.taskman.logic.commands.AddCommand;
 import seedu.taskman.commons.core.Messages;
+import seedu.taskman.logic.commands.AddCommand;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.testutil.TestTask;
 import seedu.taskman.testutil.TestUtil;
 
@@ -26,8 +26,12 @@ public class AddCommandTest extends TaskManGuiTest {
 
         //add duplicate task
         commandBox.runCommand(td.hoon.getAddCommand());
+        Activity[] expectedList = new Activity[currentList.length];
+        for(int i = 0; i < expectedList.length; i++){
+            expectedList[i] = new Activity(currentList[i]);
+        }
         assertResultMessage(AddCommand.MESSAGE_DUPLICATE_PERSON);
-        assertTrue(taskListPanel.isListMatching(currentList));
+        assertTrue(taskListPanel.isListMatching(expectedList));
 
         //add to empty list
         commandBox.runCommand("clear");
@@ -43,11 +47,15 @@ public class AddCommandTest extends TaskManGuiTest {
 
         //confirm the new card contains the right data
         TaskCardHandle addedCard = taskListPanel.navigateToTask(taskToAdd.getTitle().title);
-        assertMatching(taskToAdd, addedCard);
+        assertMatching(new Activity(taskToAdd), addedCard);
 
         //confirm the list now contains all previous tasks plus the new task
         TestTask[] expectedList = TestUtil.addTasksToList(currentList, taskToAdd);
-        assertTrue(taskListPanel.isListMatching(expectedList));
+        Activity[] expectedActivityList = new Activity[currentList.length];
+        for(int i = 0; i < expectedActivityList.length; i++){
+            expectedActivityList[i] = new Activity(expectedList[i]);
+        }
+        assertTrue(taskListPanel.isListMatching(expectedActivityList));
     }
 
 }

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -1,6 +1,7 @@
 package guitests;
 
-import org.junit.Test;
+import seedu.taskman.model.event.Activity;
+import seedu.taskman.testutil.TestTask;
 
 import static org.junit.Assert.assertTrue;
 
@@ -10,12 +11,17 @@ public class ClearCommandTest extends TaskManGuiTest {
     public void clear() {
 
         //verify a non-empty list can be cleared
-        assertTrue(taskListPanel.isListMatching(td.getTypicalTasks()));
+        TestTask[] currentList= td.getTypicalTasks();
+        Activity[] expectedList = new Activity[currentList.length];
+        for(int i = 0; i < expectedList.length; i++){
+            expectedList[i] = new Activity(currentList[i]);
+        }
+        assertTrue(taskListPanel.isListMatching(expectedList));
         assertClearCommandSuccess();
 
         //verify other commands can work after a clear command
         commandBox.runCommand(td.hoon.getAddCommand());
-        assertTrue(taskListPanel.isListMatching(td.hoon));
+        assertTrue(taskListPanel.isListMatching(new Activity(td.hoon)));
         commandBox.runCommand("delete 1");
         assertListSize(0);
 

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -1,6 +1,6 @@
 package guitests;
 
-import org.junit.Test;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.testutil.TestTask;
 import seedu.taskman.testutil.TestUtil;
 
@@ -41,11 +41,14 @@ public class DeleteCommandTest extends TaskManGuiTest {
     private void assertDeleteSuccess(int targetIndexOneIndexed, final TestTask[] currentList) {
         TestTask taskToDelete = currentList[targetIndexOneIndexed-1]; //-1 because array uses zero indexing
         TestTask[] expectedRemainder = TestUtil.removeTaskFromList(currentList, targetIndexOneIndexed);
-
+        Activity[] expectedRemainderActivities = new Activity[expectedRemainder.length];
+        for(int i = 0; i < expectedRemainderActivities.length; i++){
+            expectedRemainderActivities[i] = new Activity(expectedRemainder[i]);
+        }
         commandBox.runCommand("delete " + targetIndexOneIndexed);
 
         //confirm the list now contains all previous tasks except the deleted task
-        assertTrue(taskListPanel.isListMatching(expectedRemainder));
+        assertTrue(taskListPanel.isListMatching(expectedRemainderActivities));
 
         //confirm the result message is correct
         assertResultMessage(String.format(MESSAGE_DELETE_PERSON_SUCCESS, taskToDelete));

--- a/src/test/java/guitests/ListCommandTest.java
+++ b/src/test/java/guitests/ListCommandTest.java
@@ -1,7 +1,7 @@
 package guitests;
 
-import org.junit.Test;
 import seedu.taskman.commons.core.Messages;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.testutil.TestTask;
 
 import static org.junit.Assert.assertTrue;
@@ -32,8 +32,12 @@ public class ListCommandTest extends TaskManGuiTest {
 
     private void assertListResult(String command, TestTask... expectedHits ) {
         commandBox.runCommand(command);
-        assertListSize(expectedHits.length);
-        assertResultMessage(expectedHits.length + " tasks listed!");
-        assertTrue(taskListPanel.isListMatching(expectedHits));
+        Activity[] expectedActivities = new Activity[expectedHits.length];
+        for(int i = 0; i < expectedHits.length; i++){
+            expectedActivities[i] = new Activity(expectedHits[i]);
+        }
+        assertListSize(expectedActivities.length);
+        assertResultMessage(expectedActivities.length + " tasks listed!");
+        assertTrue(taskListPanel.isListMatching(expectedActivities));
     }
 }

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -1,8 +1,6 @@
 package guitests;
 
-import org.junit.Test;
-
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,7 +45,7 @@ public class SelectCommandTest extends TaskManGuiTest {
 
     private void assertTaskSelected(int index) {
         assertEquals(taskListPanel.getSelectedTasks().size(), 1);
-        ReadOnlyTask selectedTask = taskListPanel.getSelectedTasks().get(0);
+        Activity selectedTask = taskListPanel.getSelectedTasks().get(0);
         assertEquals(taskListPanel.getTask(index-1), selectedTask);
         //TODO: confirm the correct page is loaded in the Browser Panel
     }

--- a/src/test/java/guitests/TaskManGuiTest.java
+++ b/src/test/java/guitests/TaskManGuiTest.java
@@ -11,7 +11,7 @@ import org.testfx.api.FxToolkit;
 import seedu.taskman.TestApp;
 import seedu.taskman.commons.core.EventsCenter;
 import seedu.taskman.model.TaskMan;
-import seedu.taskman.model.event.ReadOnlyTask;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.testutil.TestUtil;
 import seedu.taskman.testutil.TypicalTestTasks;
 
@@ -96,7 +96,7 @@ public abstract class TaskManGuiTest {
     /**
      * Asserts the task shown in the card is same as the given task
      */
-    public void assertMatching(ReadOnlyTask task, TaskCardHandle card) {
+    public void assertMatching(Activity task, TaskCardHandle card) {
         assertTrue(TestUtil.compareCardAndTask(card, task));
     }
 

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -3,8 +3,7 @@ package guitests.guihandles;
 import guitests.GuiRobot;
 import javafx.scene.Node;
 import javafx.stage.Stage;
-import seedu.taskman.model.event.ReadOnlyTask;
-import seedu.taskman.model.event.Task;
+import seedu.taskman.model.event.Activity;
 
 /**
  * Provides a handle to a task card in the task list panel.
@@ -47,10 +46,10 @@ public class TaskCardHandle extends GuiHandle {
         return getTextFromLabel(SCHEDULE_FIELD_ID);
     }
     
-    public boolean isSameTask(ReadOnlyTask task){
+    public boolean isSameTask(Activity task){
         return getFullTitle().equals(task.getTitle().title)
-        		&& getDeadline().equals(((Task) task).getDeadline().toString())
-                && getStatus().equals(((Task) task).getStatus().toString())
+        		&& getDeadline().equals(task.getDeadline().toString())
+                && getStatus().equals(task.getStatus().toString())
                 && getReadOnlyTask().equals(task.getFrequency().toString())
                 && getSchedule().equals(task.getSchedule().toString());
     }

--- a/src/test/java/guitests/guihandles/TaskListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/TaskListPanelHandle.java
@@ -7,8 +7,7 @@ import javafx.scene.Node;
 import javafx.scene.control.ListView;
 import javafx.stage.Stage;
 import seedu.taskman.TestApp;
-import seedu.taskman.model.event.ReadOnlyTask;
-import seedu.taskman.model.event.Task;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.testutil.TestUtil;
 
 import java.util.List;
@@ -31,20 +30,20 @@ public class TaskListPanelHandle extends GuiHandle {
         super(guiRobot, primaryStage, TestApp.APP_TITLE);
     }
 
-    public List<ReadOnlyTask> getSelectedTasks() {
-        ListView<ReadOnlyTask> taskList = getListView();
+    public List<Activity> getSelectedTasks() {
+        ListView<Activity> taskList = getListView();
         return taskList.getSelectionModel().getSelectedItems();
     }
 
-    public ListView<ReadOnlyTask> getListView() {
-        return (ListView<ReadOnlyTask>) getNode(PERSON_LIST_VIEW_ID);
+    public ListView<Activity> getListView() {
+        return (ListView<Activity>) getNode(PERSON_LIST_VIEW_ID);
     }
 
     /**
      * Returns true if the list is showing the task details correctly and in correct order.
      * @param tasks A list of task in the correct order.
      */
-    public boolean isListMatching(ReadOnlyTask... tasks) {
+    public boolean isListMatching(Activity... tasks) {
         return this.isListMatching(0, tasks);
     }
     
@@ -59,8 +58,8 @@ public class TaskListPanelHandle extends GuiHandle {
     /**
      * Returns true if the {@code tasks} appear as the sub list (in that order) at position {@code startPosition}.
      */
-    public boolean containsInOrder(int startPosition, ReadOnlyTask... tasks) {
-        List<ReadOnlyTask> tasksInList = getListView().getItems();
+    public boolean containsInOrder(int startPosition, Activity... tasks) {
+        List<Activity> tasksInList = getListView().getItems();
 
         // Return false if the list in panel is too short to contain the given list
         if (startPosition + tasks.length > tasksInList.size()){
@@ -82,7 +81,7 @@ public class TaskListPanelHandle extends GuiHandle {
      * @param startPosition The starting position of the sub list.
      * @param tasks A list of task in the correct order.
      */
-    public boolean isListMatching(int startPosition, ReadOnlyTask... tasks) throws IllegalArgumentException {
+    public boolean isListMatching(int startPosition, Activity... tasks) throws IllegalArgumentException {
         if (tasks.length + startPosition != getListView().getItems().size()) {
             throw new IllegalArgumentException("List size mismatched\n" +
                     "Expected " + (getListView().getItems().size() - 1) + " tasks");
@@ -102,7 +101,7 @@ public class TaskListPanelHandle extends GuiHandle {
 
     public TaskCardHandle navigateToTask(String title) {
         guiRobot.sleep(500); //Allow a bit of time for the list to be updated
-        final Optional<ReadOnlyTask> task = getListView().getItems().stream().filter(p -> p.getTitle().title.equals(title)).findAny();
+        final Optional<Activity> task = getListView().getItems().stream().filter(p -> p.getTitle().title.equals(title)).findAny();
         if (!task.isPresent()) {
             throw new IllegalStateException("Title not found: " + title);
         }
@@ -113,7 +112,7 @@ public class TaskListPanelHandle extends GuiHandle {
     /**
      * Navigates the listview to display and select the task.
      */
-    public TaskCardHandle navigateToTask(ReadOnlyTask task) {
+    public TaskCardHandle navigateToTask(Activity task) {
         int index = getTaskIndex(task);
 
         guiRobot.interact(() -> {
@@ -129,8 +128,8 @@ public class TaskListPanelHandle extends GuiHandle {
     /**
      * Returns the position of the task given, {@code NOT_FOUND} if not found in the list.
      */
-    public int getTaskIndex(ReadOnlyTask targetTask) {
-        List<ReadOnlyTask> tasksInList = getListView().getItems();
+    public int getTaskIndex(Activity targetTask) {
+        List<Activity> tasksInList = getListView().getItems();
         for (int i = 0; i < tasksInList.size(); i++) {
             if(tasksInList.get(i).getTitle().equals(targetTask.getTitle())){
                 return i;
@@ -142,15 +141,15 @@ public class TaskListPanelHandle extends GuiHandle {
     /**
      * Gets a task from the list by index
      */
-    public ReadOnlyTask getTask(int index) {
+    public Activity getTask(int index) {
         return getListView().getItems().get(index);
     }
 
     public TaskCardHandle getTaskCardHandle(int index) {
-        return getTaskCardHandle(new Task(getListView().getItems().get(index)));
+        return getTaskCardHandle(new Activity(getListView().getItems().get(index)));
     }
 
-    public TaskCardHandle getTaskCardHandle(ReadOnlyTask task) {
+    public TaskCardHandle getTaskCardHandle(Activity task) {
         Set<Node> nodes = getAllCardNodes();
         Optional<Node> taskCardNode = nodes.stream()
                 .filter(n -> new TaskCardHandle(guiRobot, primaryStage, n).isSameTask(task))

--- a/src/test/java/seedu/taskman/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/taskman/commons/util/XmlUtilTest.java
@@ -52,7 +52,7 @@ public class XmlUtilTest {
     @Test
     public void getDataFromFile_validFile_validResult() throws Exception {
         XmlSerializableTaskMan dataFromFile = XmlUtil.getDataFromFile(VALID_FILE, XmlSerializableTaskMan.class);
-        assertEquals(9, dataFromFile.getTaskList().size());
+        assertEquals(9, dataFromFile.getActivityList().size());
         assertEquals(0, dataFromFile.getTagList().size());
     }
 

--- a/src/test/java/seedu/taskman/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/taskman/logic/LogicManagerTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -104,14 +105,14 @@ public class LogicManagerTest {
      */
     private void assertCommandBehavior(String inputCommand, String expectedMessage,
                                        ReadOnlyTaskMan expectedTaskMan,
-                                       List<? extends ReadOnlyTask> expectedShownList) throws Exception {
+                                       List<? extends Activity> expectedShownList) throws Exception {
 
         //Execute the command
         CommandResult result = logic.execute(inputCommand);
 
         //Confirm the ui display elements should contain the right data
         assertEquals(expectedMessage, result.feedbackToUser);
-        assertEquals(expectedShownList, model.getFilteredTaskList());
+        assertEquals(expectedShownList, model.getFilteredActivityList());
 
         //Confirm the state of data (saved and in-memory) is as expected
         assertEquals(expectedTaskMan, model.getTaskMan());
@@ -185,7 +186,7 @@ public class LogicManagerTest {
         assertCommandBehavior(helper.generateAddCommand(toBeAdded),
                 String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
                 expectedAB,
-                expectedAB.getTaskList());
+                expectedAB.getActivityList());
 
     }
 
@@ -205,7 +206,7 @@ public class LogicManagerTest {
                 helper.generateAddCommand(toBeAdded),
                 AddCommand.MESSAGE_DUPLICATE_PERSON,
                 expectedAB,
-                expectedAB.getTaskList());
+                expectedAB.getActivityList());
 
     }
 
@@ -215,7 +216,7 @@ public class LogicManagerTest {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
         TaskMan expectedAB = helper.generateTaskMan(2);
-        List<? extends ReadOnlyTask> expectedList = expectedAB.getTaskList();
+        List<? extends Activity> expectedList = expectedAB.getActivityList();
 
         // prepare task man state
         helper.addToModel(model, 2);
@@ -256,7 +257,8 @@ public class LogicManagerTest {
             model.addTask(p);
         }
 
-        assertCommandBehavior(commandWord + " 3", expectedMessage, model.getTaskMan(), taskList);
+        List<Activity> expectedList = taskList.stream().map(Activity::new).collect(Collectors.toList());
+        assertCommandBehavior(commandWord + " 3", expectedMessage, model.getTaskMan(), expectedList);
     }
 
     //@Test
@@ -281,9 +283,9 @@ public class LogicManagerTest {
         assertCommandBehavior("select 2",
                 String.format(SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS, 2),
                 expectedAB,
-                expectedAB.getTaskList());
+                expectedAB.getActivityList());
         assertEquals(1, targetedJumpIndex);
-        assertEquals(model.getFilteredTaskList().get(1), threeTasks.get(1));
+        assertEquals(model.getFilteredActivityList().get(1), threeTasks.get(1));
     }
 
 
@@ -304,13 +306,14 @@ public class LogicManagerTest {
         List<Task> threeTasks = helper.generateTaskList(3);
 
         TaskMan expectedAB = helper.generateTaskMan(threeTasks);
-        expectedAB.removeTask(threeTasks.get(1));
+        //Wrap Task in Activity to delete
+        expectedAB.removeActivity(new Activity(threeTasks.get(1)));
         helper.addToModel(model, threeTasks);
 
         assertCommandBehavior("delete 2",
                 String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, threeTasks.get(1)),
                 expectedAB,
-                expectedAB.getTaskList());
+                expectedAB.getActivityList());
     }
 
 
@@ -330,7 +333,8 @@ public class LogicManagerTest {
 
         List<Task> fourTasks = helper.generateTaskList(p1, pTarget1, p2, pTarget2);
         TaskMan expectedAB = helper.generateTaskMan(fourTasks);
-        List<Task> expectedList = helper.generateTaskList(pTarget1, pTarget2);
+        Activity[] list = {new Activity(pTarget1), new Activity(pTarget2)};
+        List<Activity> expectedList = Arrays.asList(list);
         helper.addToModel(model, fourTasks);
 
         assertCommandBehavior("list KEY",
@@ -349,7 +353,8 @@ public class LogicManagerTest {
 
         List<Task> fourTasks = helper.generateTaskList(p3, p1, p4, p2);
         TaskMan expectedAB = helper.generateTaskMan(fourTasks);
-        List<Task> expectedList = fourTasks;
+        Activity[] list = {new Activity(p3), new Activity(p1), new Activity(p4), new Activity(p2)};
+        List<Activity> expectedList = Arrays.asList(list);
         helper.addToModel(model, fourTasks);
 
         assertCommandBehavior("list KEY",
@@ -368,7 +373,8 @@ public class LogicManagerTest {
 
         List<Task> fourTasks = helper.generateTaskList(pTarget1, p1, pTarget2, pTarget3);
         TaskMan expectedAB = helper.generateTaskMan(fourTasks);
-        List<Task> expectedList = helper.generateTaskList(pTarget1, pTarget2, pTarget3);
+        Activity[] list = {new Activity(pTarget1), new Activity(pTarget2), new Activity(pTarget3)};
+        List<Activity> expectedList = Arrays.asList(list);
         helper.addToModel(model, fourTasks);
 
         assertCommandBehavior("list key rAnDoM",

--- a/src/test/java/seedu/taskman/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/taskman/storage/StorageManagerTest.java
@@ -10,14 +10,10 @@ import seedu.taskman.commons.events.storage.DataSavingExceptionEvent;
 import seedu.taskman.model.TaskMan;
 import seedu.taskman.model.ReadOnlyTaskMan;
 import seedu.taskman.model.UserPrefs;
-import seedu.taskman.model.event.Task;
-import seedu.taskman.model.event.UniqueTaskList;
 import seedu.taskman.testutil.TypicalTestTasks;
 import seedu.taskman.testutil.EventsCollector;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.logging.Logger;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/seedu/taskman/storage/XmlTaskManStorageTest.java
+++ b/src/test/java/seedu/taskman/storage/XmlTaskManStorageTest.java
@@ -9,6 +9,7 @@ import seedu.taskman.commons.exceptions.DataConversionException;
 import seedu.taskman.commons.util.FileUtil;
 import seedu.taskman.model.TaskMan;
 import seedu.taskman.model.ReadOnlyTaskMan;
+import seedu.taskman.model.event.Activity;
 import seedu.taskman.model.event.Task;
 import seedu.taskman.testutil.TypicalTestTasks;
 
@@ -72,7 +73,7 @@ public class XmlTaskManStorageTest {
 
         //Modify data, overwrite exiting file, and read back
         original.addTask(new Task(TypicalTestTasks.hoon));
-        original.removeTask(new Task(TypicalTestTasks.alice));
+        original.removeActivity(new Activity(new Task(TypicalTestTasks.alice)));
         xmlTaskManStorage.saveTaskMan(original, filePath);
         readBack = xmlTaskManStorage.readTaskMan(filePath).get();
         assertEquals(original, new TaskMan(readBack));

--- a/src/test/java/seedu/taskman/testutil/TaskManBuilder.java
+++ b/src/test/java/seedu/taskman/testutil/TaskManBuilder.java
@@ -2,9 +2,9 @@ package seedu.taskman.testutil;
 
 import seedu.taskman.commons.exceptions.IllegalValueException;
 import seedu.taskman.model.TaskMan;
-import seedu.taskman.model.tag.Tag;
 import seedu.taskman.model.event.Task;
-import seedu.taskman.model.event.UniqueTaskList;
+import seedu.taskman.model.event.UniqueActivityList;
+import seedu.taskman.model.tag.Tag;
 
 /**
  * A utility class to help with building TaskMan objects.
@@ -19,7 +19,7 @@ public class TaskManBuilder {
         this.taskMan = taskMan;
     }
 
-    public TaskManBuilder withTask(Task task) throws UniqueTaskList.DuplicateTaskException {
+    public TaskManBuilder withTask(Task task) throws UniqueActivityList.DuplicateTaskException {
         taskMan.addTask(task);
         return this;
     }

--- a/src/test/java/seedu/taskman/testutil/TaskManBuilder.java
+++ b/src/test/java/seedu/taskman/testutil/TaskManBuilder.java
@@ -19,7 +19,7 @@ public class TaskManBuilder {
         this.taskMan = taskMan;
     }
 
-    public TaskManBuilder withTask(Task task) throws UniqueActivityList.DuplicateTaskException {
+    public TaskManBuilder withTask(Task task) throws UniqueActivityList.DuplicateActivityException {
         taskMan.addTask(task);
         return this;
     }

--- a/src/test/java/seedu/taskman/testutil/TestUtil.java
+++ b/src/test/java/seedu/taskman/testutil/TestUtil.java
@@ -135,7 +135,7 @@ public class TestUtil {
     }
 
     public static TaskMan generateEmptyTaskMan() {
-        return new TaskMan(new UniqueTaskList(), new UniqueTagList());
+        return new TaskMan(new UniqueActivityList(), new UniqueTagList());
     }
 
     public static XmlSerializableTaskMan generateSampleStorageTaskMan() {
@@ -326,7 +326,7 @@ public class TestUtil {
         return list;
     }
 
-    public static boolean compareCardAndTask(TaskCardHandle card, ReadOnlyTask task) {
+    public static boolean compareCardAndTask(TaskCardHandle card, Activity task) {
         return card.isSameTask(task);
     }
 

--- a/src/test/java/seedu/taskman/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/taskman/testutil/TypicalTestTasks.java
@@ -42,7 +42,7 @@ public class TypicalTestTasks {
             ab.addTask(new Task(elle));
             ab.addTask(new Task(fiona));
             ab.addTask(new Task(george));
-        } catch (UniqueActivityList.DuplicateTaskException e) {
+        } catch (UniqueActivityList.DuplicateActivityException e) {
             assert false : "not possible";
         }
     }

--- a/src/test/java/seedu/taskman/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/taskman/testutil/TypicalTestTasks.java
@@ -42,7 +42,7 @@ public class TypicalTestTasks {
             ab.addTask(new Task(elle));
             ab.addTask(new Task(fiona));
             ab.addTask(new Task(george));
-        } catch (UniqueTaskList.DuplicateTaskException e) {
+        } catch (UniqueActivityList.DuplicateTaskException e) {
             assert false : "not possible";
         }
     }


### PR DESCRIPTION
Added Activity - wrapper class for ReadOnlyEvent and ReadOnlyTask.
Replaced ReadOnlyTask with Activity as the type for event/tasks objects to be handled in the other units.
Note: variables name of Activity instances in UI may be `task`-related.
