### PR TITLE
Implement MutableTagsEvent Interface

### DIFF
--- a/src/main/java/seedu/taskman/model/TaskMan.java
+++ b/src/main/java/seedu/taskman/model/TaskMan.java
@@ -2,6 +2,7 @@ package seedu.taskman.model;
 
 import javafx.collections.ObservableList;
 import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.MutableTagsEvent;
 import seedu.taskman.model.tag.Tag;
 import seedu.taskman.model.tag.UniqueTagList;
 import seedu.taskman.model.event.Task;
@@ -91,9 +92,9 @@ public class TaskMan implements ReadOnlyTaskMan {
      *  - points to a Tag object in the master list
      *  TODO: feels like a pretty complex way to do this... can we do better?
      */
-    private void syncTagsWithMasterList(Task task) {
-        final UniqueTagList taskTags = task.getTags();
-        tags.mergeFrom(taskTags);
+    private void syncTagsWithMasterList(MutableTagsEvent event) {
+        final UniqueTagList eventTags = event.getTags();
+        tags.mergeFrom(eventTags);
 
         // Create map with values = tag object references in the master list
         final Map<Tag, Tag> masterTagObjects = new HashMap<>();
@@ -101,12 +102,12 @@ public class TaskMan implements ReadOnlyTaskMan {
             masterTagObjects.put(tag, tag);
         }
 
-        // Rebuild the list of task tags using references from the master list
+        // Rebuild the list of event tags using references from the master list
         final Set<Tag> commonTagReferences = new HashSet<>();
-        for (Tag tag : taskTags) {
+        for (Tag tag : eventTags) {
             commonTagReferences.add(masterTagObjects.get(tag));
         }
-        task.setTags(new UniqueTagList(commonTagReferences));
+        event.setTags(new UniqueTagList(commonTagReferences));
     }
 
     public boolean removeActivity(Activity key) throws UniqueActivityList.ActivityNotFoundException {

--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -6,21 +6,21 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Wrapper for both ReadOnlyEvent and ReadOnlyTask
+ * Wrapper for both Event and Task
  */
-public class Activity implements ReadOnlyEvent{
+public class Activity implements ReadOnlyEvent, MutableTagsEvent{
 
-    public enum ActivityType {EVENT, TASK};
+    public enum ActivityType {EVENT, TASK}
 
-    private ReadOnlyEvent activity;
+    private MutableTagsEvent activity;
     private ActivityType type;
 
-    public Activity(ReadOnlyEvent event){
+    public Activity(Event event){
         activity = event;
         type = ActivityType.EVENT;
     }
 
-    public Activity(ReadOnlyTask task){
+    public Activity(Task task){
         activity = task;
         type = ActivityType.TASK;
     }
@@ -91,6 +91,11 @@ public class Activity implements ReadOnlyEvent{
     @Override
     public Optional<Schedule> getSchedule() {
         return activity.getSchedule();
+    }
+
+    @Override
+    public void setTags(UniqueTagList replacement) {
+        activity.setTags(replacement);
     }
 
     @Override

--- a/src/main/java/seedu/taskman/model/event/Event.java
+++ b/src/main/java/seedu/taskman/model/event/Event.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  * Represents a Task in the task man.
  * Guarantees: Title and UniqueTagList are present and not null, field values are validated.
  */
-public class Event implements ReadOnlyEvent {
+public class Event implements ReadOnlyEvent, MutableTagsEvent {
 
     private Title title;
     private Frequency frequency;

--- a/src/main/java/seedu/taskman/model/event/MutableTagsEvent.java
+++ b/src/main/java/seedu/taskman/model/event/MutableTagsEvent.java
@@ -1,0 +1,11 @@
+package seedu.taskman.model.event;
+
+import seedu.taskman.model.tag.UniqueTagList;
+
+/**
+ * An interface for classes to allow setting tags
+ */
+public interface MutableTagsEvent extends ReadOnlyEvent{
+
+    void setTags(UniqueTagList replacement);
+}

--- a/src/main/java/seedu/taskman/model/event/Task.java
+++ b/src/main/java/seedu/taskman/model/event/Task.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  * Represents a Task in the task man.
  * Guarantees: Title and UniqueTagList are present and not null, field values are validated.
  */
-public class Task extends Event implements ReadOnlyTask {
+public class Task extends Event implements ReadOnlyTask, MutableTagsEvent {
 
     private Deadline deadline;
     private Status status;

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -4,6 +4,7 @@ import guitests.guihandles.TaskCardHandle;
 import seedu.taskman.commons.core.Messages;
 import seedu.taskman.logic.commands.AddCommand;
 import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.Task;
 import seedu.taskman.testutil.TestTask;
 import seedu.taskman.testutil.TestUtil;
 
@@ -28,7 +29,7 @@ public class AddCommandTest extends TaskManGuiTest {
         commandBox.runCommand(td.hoon.getAddCommand());
         Activity[] expectedList = new Activity[currentList.length];
         for(int i = 0; i < expectedList.length; i++){
-            expectedList[i] = new Activity(currentList[i]);
+            expectedList[i] = new Activity(new Task(currentList[i]));
         }
         assertResultMessage(AddCommand.MESSAGE_DUPLICATE_PERSON);
         assertTrue(taskListPanel.isListMatching(expectedList));
@@ -47,13 +48,13 @@ public class AddCommandTest extends TaskManGuiTest {
 
         //confirm the new card contains the right data
         TaskCardHandle addedCard = taskListPanel.navigateToTask(taskToAdd.getTitle().title);
-        assertMatching(new Activity(taskToAdd), addedCard);
+        assertMatching(new Activity(new Task(taskToAdd)), addedCard);
 
         //confirm the list now contains all previous tasks plus the new task
         TestTask[] expectedList = TestUtil.addTasksToList(currentList, taskToAdd);
         Activity[] expectedActivityList = new Activity[currentList.length];
         for(int i = 0; i < expectedActivityList.length; i++){
-            expectedActivityList[i] = new Activity(expectedList[i]);
+            expectedActivityList[i] = new Activity(new Task(expectedList[i]));
         }
         assertTrue(taskListPanel.isListMatching(expectedActivityList));
     }

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -1,6 +1,7 @@
 package guitests;
 
 import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.Task;
 import seedu.taskman.testutil.TestTask;
 
 import static org.junit.Assert.assertTrue;
@@ -14,14 +15,14 @@ public class ClearCommandTest extends TaskManGuiTest {
         TestTask[] currentList= td.getTypicalTasks();
         Activity[] expectedList = new Activity[currentList.length];
         for(int i = 0; i < expectedList.length; i++){
-            expectedList[i] = new Activity(currentList[i]);
+            expectedList[i] = new Activity(new Task(currentList[i]));
         }
         assertTrue(taskListPanel.isListMatching(expectedList));
         assertClearCommandSuccess();
 
         //verify other commands can work after a clear command
         commandBox.runCommand(td.hoon.getAddCommand());
-        assertTrue(taskListPanel.isListMatching(new Activity(td.hoon)));
+        assertTrue(taskListPanel.isListMatching(new Activity(new Task(td.hoon))));
         commandBox.runCommand("delete 1");
         assertListSize(0);
 

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -1,6 +1,7 @@
 package guitests;
 
 import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.Task;
 import seedu.taskman.testutil.TestTask;
 import seedu.taskman.testutil.TestUtil;
 
@@ -43,7 +44,7 @@ public class DeleteCommandTest extends TaskManGuiTest {
         TestTask[] expectedRemainder = TestUtil.removeTaskFromList(currentList, targetIndexOneIndexed);
         Activity[] expectedRemainderActivities = new Activity[expectedRemainder.length];
         for(int i = 0; i < expectedRemainderActivities.length; i++){
-            expectedRemainderActivities[i] = new Activity(expectedRemainder[i]);
+            expectedRemainderActivities[i] = new Activity(new Task(expectedRemainder[i]));
         }
         commandBox.runCommand("delete " + targetIndexOneIndexed);
 

--- a/src/test/java/guitests/ListCommandTest.java
+++ b/src/test/java/guitests/ListCommandTest.java
@@ -2,6 +2,7 @@ package guitests;
 
 import seedu.taskman.commons.core.Messages;
 import seedu.taskman.model.event.Activity;
+import seedu.taskman.model.event.Task;
 import seedu.taskman.testutil.TestTask;
 
 import static org.junit.Assert.assertTrue;
@@ -34,7 +35,7 @@ public class ListCommandTest extends TaskManGuiTest {
         commandBox.runCommand(command);
         Activity[] expectedActivities = new Activity[expectedHits.length];
         for(int i = 0; i < expectedHits.length; i++){
-            expectedActivities[i] = new Activity(expectedHits[i]);
+            expectedActivities[i] = new Activity(new Task(expectedHits[i]));
         }
         assertListSize(expectedActivities.length);
         assertResultMessage(expectedActivities.length + " tasks listed!");


### PR DESCRIPTION
Events and Tasks (and Activity) should have mutable tags. The interface serves to make methods TaskMan easier to implement (eg. syncTags...)  
- [x] Create MutableTagsEvent Interface
- [x] Implement interface for Event, Task and Activity
- [x] Refactor method in TaskMan 
