### PR TITLE
Add word wrap to result box

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -127,6 +127,7 @@
 
 .result-display {
     -fx-background-color: #ffffff;
+    -fx-wrap-text: true;
 }
 
 .result-display .label {


### PR DESCRIPTION
1. So that there will be no horizontal scroll bar
2. Other problems: When history is typed, cannot use key arrows to scroll it down
#106
