### PR TITLE
Fixes invalid Title bug when only tags are edited

### DIFF
--- a/src/main/java/seedu/taskman/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/taskman/logic/commands/EditCommand.java
@@ -76,19 +76,27 @@ public class EditCommand extends Command {
 
         String panelTypeRaw = matcher.group("panel").trim();
         Activity.PanelType panelType = Activity.PanelType.fromString(panelTypeRaw);
+
         String indexString = matcher.group("targetIndex").trim();
         int index = Integer.parseInt(indexString);
 
-            String tags = matcher.group("tagArguments");
-            return new EditCommand(
-                    panelType,
-                    index,
-                    matcher.group("title"),
-                    matcher.group("deadline"),
-                    matcher.group("status"),
-                    matcher.group("schedule"),
-                    matcher.group("frequency"),
-                    tags.isEmpty() ? null : getTagsFromArgs(tags));
+        // filter out empty string
+        // an alternative would be to use non-greedy regex
+        String title = matcher.group("title");
+        if (title != null && title.trim().isEmpty()) {
+            title = null;
+        }
+
+        String tags = matcher.group("tagArguments");
+        return new EditCommand(
+                panelType,
+                index,
+                title,
+                matcher.group("deadline"),
+                matcher.group("status"),
+                matcher.group("schedule"),
+                matcher.group("frequency"),
+                tags.isEmpty() ? null : getTagsFromArgs(tags));
     }
 
     @Override


### PR DESCRIPTION
For #109 

Regex identifies whitespace as part of the title.
Bypass this problem by trimming the title & deciding if the user really added one in Edit command.
A cleaner fix could be to use non-greedy regex instead.
