### PR TITLE
Cleaning up of old activities: remove expired activities on data load

### DIFF
--- a/src/main/java/seedu/taskman/model/event/Activity.java
+++ b/src/main/java/seedu/taskman/model/event/Activity.java
@@ -128,6 +128,11 @@ public class Activity implements ReadOnlyEvent, MutableTagsEvent {
         return activity.getTags();
     }
 
+    @Override
+    public boolean isExpired() {
+        return activity.isExpired();
+    }
+
     public boolean isSameStateAs(Activity other) {
         if (type != other.type) return false;
 

--- a/src/main/java/seedu/taskman/model/event/Event.java
+++ b/src/main/java/seedu/taskman/model/event/Event.java
@@ -5,6 +5,7 @@ import seedu.taskman.model.tag.UniqueTagList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -13,7 +14,8 @@ import java.util.Optional;
  * Guarantees: Title and UniqueTagList are present and not null, field values are validated.
  */
 public class Event implements ReadOnlyEvent, MutableTagsEvent {
-
+    private static final long DAY_IN_SECONDS = 60 * 60 * 24;
+    protected static final long EXPIRY_THRESHOLD = DAY_IN_SECONDS * 7;
     private Title title;
     private Frequency frequency;
     private Schedule schedule;
@@ -56,6 +58,16 @@ public class Event implements ReadOnlyEvent, MutableTagsEvent {
     @Override
     public UniqueTagList getTags() {
         return new UniqueTagList(tags);
+    }
+
+    @Override
+    public boolean isExpired() {
+        if (schedule == null) {
+            return false;
+        }
+
+        long secondsElapsedSinceEnd = Instant.now().getEpochSecond() - schedule.endEpochSecond;
+        return secondsElapsedSinceEnd > EXPIRY_THRESHOLD;
     }
 
     /**

--- a/src/main/java/seedu/taskman/model/event/ReadOnlyEvent.java
+++ b/src/main/java/seedu/taskman/model/event/ReadOnlyEvent.java
@@ -17,6 +17,12 @@ public interface ReadOnlyEvent {
     Optional<Schedule> getSchedule();
 
     /**
+     * Expiry indicates if the event is no longer useful in business logic.
+     * A positive result gives the green light for removal from storage.
+     */
+    boolean isExpired();
+
+    /**
      * The returned TagList is a deep copy of the internal TagList,
      * changes on the returned list will not affect the event's internal tags.
      */

--- a/src/main/java/seedu/taskman/model/event/Task.java
+++ b/src/main/java/seedu/taskman/model/event/Task.java
@@ -4,6 +4,7 @@ import seedu.taskman.model.tag.UniqueTagList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -58,6 +59,15 @@ public class Task extends Event implements ReadOnlyTask, MutableTagsEvent {
     @Override
     public Status getStatus() {
         return status;
+    }
+
+    @Override
+    public boolean isExpired() {
+        if (deadline == null || !status.completed) {
+            return false;
+        }
+        long secondsElapsedSinceDeadline = Instant.now().getEpochSecond() - deadline.epochSecond;
+        return secondsElapsedSinceDeadline > EXPIRY_THRESHOLD;
     }
 
     @Override

--- a/src/test/java/seedu/taskman/testutil/TestTask.java
+++ b/src/test/java/seedu/taskman/testutil/TestTask.java
@@ -47,6 +47,12 @@ public class TestTask implements ReadOnlyTask {
     }
 
     @Override
+    public boolean isExpired() {
+        // currently unused for testing
+        return false;
+    }
+
+    @Override
     public Optional<Deadline> getDeadline() {
         return Optional.ofNullable(deadline);
     }


### PR DESCRIPTION
Events and Tasks are made to define an isExpired method. 
StorageManager filters out and ignores expired activities when loading from xml.

These ignored activities will be removed the next time StorageManager
writes to the on-disk-storage.

