### PR TITLE
Revised constrains for Tag creation

### DIFF
--- a/src/main/java/seedu/taskman/model/tag/Tag.java
+++ b/src/main/java/seedu/taskman/model/tag/Tag.java
@@ -9,8 +9,9 @@ import seedu.taskman.commons.exceptions.IllegalValueException;
  */
 public class Tag {
 
-    public static final String MESSAGE_TAG_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String TAG_VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_TAG_CONSTRAINTS = "Tag name should form a word. " +
+            "All punctuation except '/' is accepted";
+    public static final String TAG_VALIDATION_REGEX = "[\\w\\p{Punct}&&[^/]]+";
 
     public String tagName;
 


### PR DESCRIPTION
For #150 

Tag now allows punctuation as well as any character can make up a word.
'/' however, is not accepted